### PR TITLE
bug/fix_missing_servicemonitor_labels

### DIFF
--- a/charts/sakuracloud-exporter/templates/servicemonitor.yaml
+++ b/charts/sakuracloud-exporter/templates/servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "sakuracloud-exporter.fullname" . }}
   labels:
     {{- include "sakuracloud-exporter.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels}}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end}}
 spec:
   endpoints:
   - port: http


### PR DESCRIPTION
`.Values.serviceMonitor.labels` のラベルが反映されない問題を解決